### PR TITLE
ci(ai): use job condition instead of trigger_phrase for /review

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   claude-review:
-    if: github.event.issue.pull_request
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '/review')
 
     runs-on: ubuntu-24.04-arm
     permissions:
@@ -32,7 +32,6 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          trigger_phrase: '/review'
           prompt: |
             REPO: ${{ github.repository }}
             PR NUMBER: ${{ github.event.issue.number }}


### PR DESCRIPTION
## Summary

- Replaced the `trigger_phrase` parameter with a job-level condition to properly filter PR comments containing `/review`
- The `trigger_phrase` parameter in `claude-code-action` does not work correctly with PR comments triggered by `issue_comment` events

## Changes

- Added job condition: `contains(github.event.comment.body, '/review')` to check for the trigger phrase
- Removed redundant `trigger_phrase: '/review'` parameter from the action configuration

## Why This Works Better

Using a GitHub Actions job condition (`if:`) is more efficient because:
- The job won't even start unless the comment contains `/review`
- This is the standard GitHub Actions pattern for filtering events
- Avoids running unnecessary setup steps when the trigger phrase is absent